### PR TITLE
= FIX: inline function declaration

### DIFF
--- a/pico-ice40-1k/sw-probe-firmware/hardware.c
+++ b/pico-ice40-1k/sw-probe-firmware/hardware.c
@@ -63,16 +63,6 @@ void hw_systick(u32 ticks)
   reg_wr(SYSTICK_CTRL, 0x07);
 }
 
-inline u32  reg_rd(u32 reg)
-{
-  return( *(volatile u32 *)reg );
-}
-
-inline void reg_wr(u32 reg, u32 value)
-{
-  *(volatile u32 *)reg = value;
-}
-
 u8 reg_rd8_crit(u32 Addr)
 {
     uint8_t ret;

--- a/pico-ice40-1k/sw-probe-firmware/include/hardware.h
+++ b/pico-ice40-1k/sw-probe-firmware/include/hardware.h
@@ -54,6 +54,14 @@ void hw_init(void);
 u32  hw_getfreq(void);
 void hw_systick(u32 ticks);
 
-inline u32  reg_rd(u32 reg);
-inline void reg_wr(u32 reg, u32 value);
+static inline u32  reg_rd(u32 reg)
+{
+  return( *(volatile u32 *)reg );
+}
+
+static inline void reg_wr(u32 reg, u32 value)
+{
+  *(volatile u32 *)reg = value;
+}
+
 #endif

--- a/pico-ice40-1k/sw-probe-unit_test/sw-ut_flash/hardware.c
+++ b/pico-ice40-1k/sw-probe-unit_test/sw-ut_flash/hardware.c
@@ -54,17 +54,7 @@ u32 hw_getfreq(void)
   /* Compute current frequency */
   v = 0x007A1200; /* External oscillator = 8MHz */
   v = v * m / n * 1 / od;
-  
+
   return v;
-}
-
-inline u32  reg_rd(u32 reg)
-{
-  return( *(volatile u32 *)reg );
-}
-
-inline void reg_wr(u32 reg, u32 value)
-{
-  *(volatile u32 *)reg = value;
 }
 /* EOF */

--- a/pico-ice40-1k/sw-probe-unit_test/sw-ut_flash/include/hardware.h
+++ b/pico-ice40-1k/sw-probe-unit_test/sw-ut_flash/include/hardware.h
@@ -42,6 +42,13 @@
 void hw_init(void);
 u32  hw_getfreq(void);
 
-inline u32  reg_rd(u32 reg);
-inline void reg_wr(u32 reg, u32 value);
+static inline u32  reg_rd(u32 reg)
+{
+  return( *(volatile u32 *)reg );
+}
+
+static inline void reg_wr(u32 reg, u32 value)
+{
+  *(volatile u32 *)reg = value;
+}
 #endif

--- a/pico-ice40-1k/sw-probe-unit_test/sw-ut_iap/read_iap/hardware.c
+++ b/pico-ice40-1k/sw-probe-unit_test/sw-ut_iap/read_iap/hardware.c
@@ -48,17 +48,7 @@ u32 hw_getfreq(void)
   /* Compute current frequency */
   v = 0x007A1200; /* External oscillator = 8MHz */
   v = v * m / n * 1 / od;
-  
+
   return v;
-}
-
-inline u32  reg_rd(u32 reg)
-{
-  return( *(volatile u32 *)reg );
-}
-
-inline void reg_wr(u32 reg, u32 value)
-{
-  *(volatile u32 *)reg = value;
 }
 /* EOF */

--- a/pico-ice40-1k/sw-probe-unit_test/sw-ut_iap/read_iap/include/hardware.h
+++ b/pico-ice40-1k/sw-probe-unit_test/sw-ut_iap/read_iap/include/hardware.h
@@ -41,6 +41,13 @@
 void hw_init(void);
 u32  hw_getfreq(void);
 
-inline u32  reg_rd(u32 reg);
-inline void reg_wr(u32 reg, u32 value);
+static inline u32  reg_rd(u32 reg)
+{
+  return( *(volatile u32 *)reg );
+}
+
+static inline void reg_wr(u32 reg, u32 value)
+{
+  *(volatile u32 *)reg = value;
+}
 #endif

--- a/pico-ice40-1k/sw-probe-unit_test/sw-ut_miim/hardware.c
+++ b/pico-ice40-1k/sw-probe-unit_test/sw-ut_miim/hardware.c
@@ -52,17 +52,7 @@ u32 hw_getfreq(void)
   /* Compute current frequency */
   v = 0x007A1200; /* External oscillator = 8MHz */
   v = v * m / n * 1 / od;
-  
+
   return v;
-}
-
-inline u32  reg_rd(u32 reg)
-{
-  return( *(volatile u32 *)reg );
-}
-
-inline void reg_wr(u32 reg, u32 value)
-{
-  *(volatile u32 *)reg = value;
 }
 /* EOF */

--- a/pico-ice40-1k/sw-probe-unit_test/sw-ut_miim/include/hardware.h
+++ b/pico-ice40-1k/sw-probe-unit_test/sw-ut_miim/include/hardware.h
@@ -41,6 +41,13 @@
 void hw_init(void);
 u32  hw_getfreq(void);
 
-inline u32  reg_rd(u32 reg);
-inline void reg_wr(u32 reg, u32 value);
+static inline u32  reg_rd(u32 reg)
+{
+  return( *(volatile u32 *)reg );
+}
+
+static inline void reg_wr(u32 reg, u32 value)
+{
+  *(volatile u32 *)reg = value;
+}
 #endif

--- a/pico-ice40-1k/sw-probe-unit_test/sw-ut_net/hardware.c
+++ b/pico-ice40-1k/sw-probe-unit_test/sw-ut_net/hardware.c
@@ -52,17 +52,7 @@ u32 hw_getfreq(void)
   /* Compute current frequency */
   v = 0x007A1200; /* External oscillator = 8MHz */
   v = v * m / n * 1 / od;
-  
+
   return v;
-}
-
-inline u32  reg_rd(u32 reg)
-{
-  return( *(volatile u32 *)reg );
-}
-
-inline void reg_wr(u32 reg, u32 value)
-{
-  *(volatile u32 *)reg = value;
 }
 /* EOF */

--- a/pico-ice40-1k/sw-probe-unit_test/sw-ut_net/include/hardware.h
+++ b/pico-ice40-1k/sw-probe-unit_test/sw-ut_net/include/hardware.h
@@ -39,6 +39,13 @@
 void hw_init(void);
 u32  hw_getfreq(void);
 
-inline u32  reg_rd(u32 reg);
-inline void reg_wr(u32 reg, u32 value);
+static inline u32  reg_rd(u32 reg)
+{
+  return( *(volatile u32 *)reg );
+}
+
+static inline void reg_wr(u32 reg, u32 value)
+{
+  *(volatile u32 *)reg = value;
+}
 #endif

--- a/pico-ice40-1k/sw-probe-unit_test/sw-ut_oled/hardware.c
+++ b/pico-ice40-1k/sw-probe-unit_test/sw-ut_oled/hardware.c
@@ -67,17 +67,7 @@ u32 hw_getfreq(void)
   /* Compute current frequency */
   v = 0x007A1200; /* External oscillator = 8MHz */
   v = v * m / n * 1 / od;
-  
+
   return v;
-}
-
-inline u32  reg_rd(u32 reg)
-{
-  return( *(volatile u32 *)reg );
-}
-
-inline void reg_wr(u32 reg, u32 value)
-{
-  *(volatile u32 *)reg = value;
 }
 /* EOF */

--- a/pico-ice40-1k/sw-probe-unit_test/sw-ut_oled/include/hardware.h
+++ b/pico-ice40-1k/sw-probe-unit_test/sw-ut_oled/include/hardware.h
@@ -42,6 +42,13 @@
 void hw_init(void);
 u32  hw_getfreq(void);
 
-inline u32  reg_rd(u32 reg);
-inline void reg_wr(u32 reg, u32 value);
+static inline u32  reg_rd(u32 reg)
+{
+  return( *(volatile u32 *)reg );
+}
+
+static inline void reg_wr(u32 reg, u32 value)
+{
+  *(volatile u32 *)reg = value;
+}
 #endif

--- a/pico-ice40-1k/sw-probe-unit_test/sw-ut_pld_load/hardware.c
+++ b/pico-ice40-1k/sw-probe-unit_test/sw-ut_pld_load/hardware.c
@@ -56,17 +56,7 @@ u32 hw_getfreq(void)
   /* Compute current frequency */
   v = 0x007A1200; /* External oscillator = 8MHz */
   v = v * m / n * 1 / od;
-  
+
   return v;
-}
-
-inline u32  reg_rd(u32 reg)
-{
-  return( *(volatile u32 *)reg );
-}
-
-inline void reg_wr(u32 reg, u32 value)
-{
-  *(volatile u32 *)reg = value;
 }
 /* EOF */

--- a/pico-ice40-1k/sw-probe-unit_test/sw-ut_pld_load/include/hardware.h
+++ b/pico-ice40-1k/sw-probe-unit_test/sw-ut_pld_load/include/hardware.h
@@ -42,6 +42,13 @@
 void hw_init(void);
 u32  hw_getfreq(void);
 
-inline u32  reg_rd(u32 reg);
-inline void reg_wr(u32 reg, u32 value);
+static inline u32  reg_rd(u32 reg)
+{
+  return( *(volatile u32 *)reg );
+}
+
+static inline void reg_wr(u32 reg, u32 value)
+{
+  *(volatile u32 *)reg = value;
+}
 #endif

--- a/pico-ice40-1k/sw-probe-unit_test/sw-ut_reloc/boot/hardware.c
+++ b/pico-ice40-1k/sw-probe-unit_test/sw-ut_reloc/boot/hardware.c
@@ -45,17 +45,7 @@ u32 hw_getfreq(void)
   /* Compute current frequency */
   v = 0x007A1200; /* External oscillator = 8MHz */
   v = v * m / n * 1 / od;
-  
+
   return v;
-}
-
-inline u32  reg_rd(u32 reg)
-{
-  return( *(volatile u32 *)reg );
-}
-
-inline void reg_wr(u32 reg, u32 value)
-{
-  *(volatile u32 *)reg = value;
 }
 /* EOF */

--- a/pico-ice40-1k/sw-probe-unit_test/sw-ut_reloc/boot/include/hardware.h
+++ b/pico-ice40-1k/sw-probe-unit_test/sw-ut_reloc/boot/include/hardware.h
@@ -41,6 +41,13 @@
 void hw_init(void);
 u32  hw_getfreq(void);
 
-inline u32  reg_rd(u32 reg);
-inline void reg_wr(u32 reg, u32 value);
+static inline u32  reg_rd(u32 reg)
+{
+  return( *(volatile u32 *)reg );
+}
+
+static inline void reg_wr(u32 reg, u32 value)
+{
+  *(volatile u32 *)reg = value;
+}
 #endif

--- a/pico-ice40-1k/sw-probe-unit_test/sw-ut_reloc/firmware/hardware.c
+++ b/pico-ice40-1k/sw-probe-unit_test/sw-ut_reloc/firmware/hardware.c
@@ -45,17 +45,7 @@ u32 hw_getfreq(void)
   /* Compute current frequency */
   v = 0x007A1200; /* External oscillator = 8MHz */
   v = v * m / n * 1 / od;
-  
+
   return v;
-}
-
-inline u32  reg_rd(u32 reg)
-{
-  return( *(volatile u32 *)reg );
-}
-
-inline void reg_wr(u32 reg, u32 value)
-{
-  *(volatile u32 *)reg = value;
 }
 /* EOF */

--- a/pico-ice40-1k/sw-probe-unit_test/sw-ut_reloc/firmware/include/hardware.h
+++ b/pico-ice40-1k/sw-probe-unit_test/sw-ut_reloc/firmware/include/hardware.h
@@ -41,6 +41,13 @@
 void hw_init(void);
 u32  hw_getfreq(void);
 
-inline u32  reg_rd(u32 reg);
-inline void reg_wr(u32 reg, u32 value);
+static inline u32  reg_rd(u32 reg)
+{
+  return( *(volatile u32 *)reg );
+}
+
+static inline void reg_wr(u32 reg, u32 value)
+{
+  *(volatile u32 *)reg = value;
+}
 #endif


### PR DESCRIPTION
With gcc 6.1.1, the compilation failed due to undefined function `reg_rd`,
`reg_wr` and `reg_set`.

See http://www.greenend.org.uk/rjk/tech/inline.html.
